### PR TITLE
Enhanced annotations endpoint and support for checksum in search

### DIFF
--- a/app/annotations/schema.py
+++ b/app/annotations/schema.py
@@ -31,6 +31,14 @@ class Region(BaseModel):
         ..., description="The first position of the annotation", example=23
     )
     end: int = Field(..., description="The last position of the annotation", example=42)
+    annotation_value: str = Field(
+        None, description="The value of the annotation", example="0.9"
+    )
+    unit: str = Field(
+        None,
+        description="The unit of the annotation value, if applicable",
+        example="mmol",
+    )
 
 
 class Evidence(Enum):

--- a/app/app.py
+++ b/app/app.py
@@ -30,6 +30,15 @@ app = FastAPI(
     title="3D Beacons HUB API",
     description="The 3D-Beacons Network provides unified programmatic access to "
     "experimentally determined and predicted structure models.",
+    contact={
+        "name": "3D-Beacons Network",
+        "url": "https://3dbeacons.org",
+        "email": "pdbekb_help@ebi.ac.uk",
+    },
+    license_info={
+        "name": "CC BY 4.0",
+        "url": "https://creativecommons.org/licenses/by/4.0/",
+    },
     redoc_url=None,
     version=schema_version,
 )

--- a/app/constants.py
+++ b/app/constants.py
@@ -3,6 +3,10 @@ UNIPROT_AC_DESC = "UniProt accession, e.g. P00520"
 UNIPROT_ID_DESC = "UniProt identifier, e.g. ABL1_MOUSE"
 UNIPROT_RANGE_DESC = "Specify a UniProt sequence residue range; separated by hyphen(-)."
 UNIPROT_QUAL_DESC = "UniProtKB accession number (AC) or entry name (ID)"
+QUERY_DESC = (
+    "UniProtKB accession number (AC), entry name (ID) or CRC64 checksum "
+    "of the UniProt sequence"
+)
 TEMPLATE_DESC = (
     "Template is 4 letter PDB code, or 4 letter code with "
     "assembly ID and chain for SMTL entries"

--- a/app/uniprot/uniprot.py
+++ b/app/uniprot/uniprot.py
@@ -8,7 +8,12 @@ from starlette.responses import JSONResponse
 
 from app import logger
 from app.config import get_base_service_url, get_services
-from app.constants import TEMPLATE_DESC, UNIPROT_QUAL_DESC, UNP_CHECKSUM_DESC
+from app.constants import (
+    QUERY_DESC,
+    TEMPLATE_DESC,
+    UNIPROT_QUAL_DESC,
+    UNP_CHECKSUM_DESC,
+)
 from app.uniprot.helper import (
     filter_on_checksum,
     get_first_entry_with_checksum,
@@ -33,9 +38,17 @@ uniprot_route = APIRouter()
     response_model=UniprotSummary,
     response_model_exclude_unset=True,
     tags=["UniProt"],
+    description="""
+    Retrieve a summary of experimentally determined and predicted structure models
+    available for a UniProtKB accession, entry name, or CRC64 checksum associated
+    with a UniProt sequence.
+
+    Note that some model providers may not support searches by entry name or
+    CRC64 checksum.
+    """,
 )
 async def get_uniprot_summary(
-    qualifier: Any = Path(..., description=UNIPROT_QUAL_DESC, example="P38398"),
+    qualifier: Any = Path(..., description=QUERY_DESC, example="P38398"),
     provider: Optional[Any] = Query(
         None, enum=[x["provider"] for x in get_services("summary")]
     ),
@@ -60,7 +73,7 @@ async def get_uniprot_summary(
     accession or entry name
 
     Args:
-        qualifier (str): {UNIPROT_QUAL_DESC}
+        qualifier (str): {QUERY_DESC}
         provider (str, optional): Data provider
         template (str, optional): {TEMPLATE_DESC}
         res_range (str, optional): Residue range
@@ -202,11 +215,19 @@ async def get_uniprot_helper(
     status_code=status.HTTP_200_OK,
     response_model=UniprotDetails,
     tags=["UniProt"],
+    description="""
+    Retrieve residue-level mappings for experimentally determined and predicted
+    structure models available for a UniProtKB accession, entry name, or CRC64
+    checksum associated with a UniProt sequence.
+
+    Note that some model providers may not support searches by entry name or
+    CRC64 checksum.
+    """,
 )
 async def get_uniprot(
     qualifier: Any = Path(
         ...,
-        description="UniProtKB accession number (AC) or entry name (ID)",
+        description=QUERY_DESC,
         example="P38398",
     ),
     provider: Optional[Any] = Query(
@@ -228,7 +249,7 @@ async def get_uniprot(
     f"""Returns experimental and theoretical models for a UniProt accession or entry name
 
     Args:
-        qualifier (str): {UNIPROT_QUAL_DESC}
+        qualifier (str): {QUERY_DESC}
         provider (str, optional): Data provider
         template (str, optional): {TEMPLATE_DESC}
         res_range (str, optional): Residue range

--- a/app/version.py
+++ b/app/version.py
@@ -1,2 +1,2 @@
-__version__ = "2.5.1"
+__version__ = "2.6.0"
 __major__version__ = f"{__version__.split('.')[0]}.0.0"


### PR DESCRIPTION
This pull request includes several updates to the `app` module, focusing on enhancing the annotation schema, updating API documentation, and improving the description for UniProt-related endpoints. Additionally, the version of the application has been incremented.

### Enhancements to the annotation schema:
* Added `annotation_value` and `unit` fields to the `Region` class in `app/annotations/schema.py` to store the value and unit of the annotation.

### API documentation updates:
* Added contact and license information to the API documentation in `app/app.py` for better clarity.

### Improvements to UniProt-related endpoints:
* Added a new constant `QUERY_DESC` to `app/constants.py` for describing UniProt query parameters.
* Updated the import statements in `app/uniprot/uniprot.py` to include `QUERY_DESC`.
* Enhanced the descriptions for the `get_uniprot_summary` and `get_uniprot` functions to support searches by UniProtKB accession, entry name, or CRC64 checksum. [[1]](diffhunk://#diff-c49a358ec4046f451af08c67900d5184346095824b24674f8ed6ac99b6545dfcR41-R51) [[2]](diffhunk://#diff-c49a358ec4046f451af08c67900d5184346095824b24674f8ed6ac99b6545dfcL63-R76) [[3]](diffhunk://#diff-c49a358ec4046f451af08c67900d5184346095824b24674f8ed6ac99b6545dfcR218-R230) [[4]](diffhunk://#diff-c49a358ec4046f451af08c67900d5184346095824b24674f8ed6ac99b6545dfcL231-R252)

### Version update:
* Incremented the application version from `2.5.1` to `2.6.0` in `app/version.py`.