### PR TITLE
Remove trust_env=False from httpx.AsyncClient in request_post to allo…

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -53,7 +53,7 @@ async def request_get(url: str):
 
 async def request_post(url: str, data):
     response = None
-    async with httpx.AsyncClient(trust_env=False) as client:
+    async with httpx.AsyncClient() as client:
         try:
             response = await client.post(url, timeout=REQUEST_TIMEOUT, data=data)
         except httpx.TimeoutException:


### PR DESCRIPTION
This pull request makes a small change to the HTTP client configuration in the `request_post` utility function, removing the `trust_env=False` parameter from the `httpx.AsyncClient` instantiation. This means the client will now respect environment variables for proxy and configuration by default.